### PR TITLE
Adding files for python logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # highlightjs-pythonlogging
-Python Logging output highlighting
+
+This is a simple addition to th Syntax highligher [highlight.js](https://github.com/highlightjs/highlight.js)
+to allow for highlighting of Python Logging output:
+
+[python-logging.png](python-logging.png)
+
+Since we can't choose colors to match with the levels, it's up to the user
+to select a theme to his or her preference. There is no "official" documentation
+for how to add a custom language, but generally you can clone highlight.js:
+
+```bash
+git clone https://www.github.com/highlightjs/highlight.js
+cd highlight.js
+```
+
+Copy the files here to that repository:
+
+```bash
+cp -R ../highlightjs-pythonlogging/test/detect/pythonlogging test/detect/
+cp ../highlightjs-pythonlogging/src/pythonlogging.js src/languages/
+```
+
+And then follow instructions to build the library (either with or without
+a container) to generate the compiled library.

--- a/src/languages/pythonlogging.js
+++ b/src/languages/pythonlogging.js
@@ -1,0 +1,78 @@
+/*
+Language: Python (Logging Output)
+Description: Python has standard logging that can be colored based on a logging level
+Author: Vanessa Sochat <@vsoch>
+Website: https://docs.python.org/3/library/logging.html
+Category: common
+*/
+
+function(hljs) {
+  return {
+    aliases: ['pythonlogging'],
+    contains: [
+
+      // FATAL or ERROR
+      {
+        className: 'title',
+        variants: [
+          { begin: '^FATAL', end: ':' },
+          { begin: '^ERROR', end: ':' }
+        ]
+      },
+
+      // CRITICAL
+      {
+        className: 'function',
+        variants: [
+          { begin: '^CRITICAL', end: ':' }
+        ]
+      },
+
+      // WARNING
+      {
+        className: 'variable',
+        variants: [
+          { begin: '^WARNING', end: ':' }
+        ]
+      },
+
+      // INFO statements
+      {
+        className: 'string',
+        variants: [
+          { begin: '^INFO', end: ':' }
+        ]
+      },
+
+      // INFO statements
+      {
+        className: 'meta',
+        variants: [
+          { begin: '^LOG', end: ':' }
+        ]
+      },
+
+      // DEBUG statements
+      {
+        className: 'message',
+        variants: [
+          { begin: '^DEBUG', end: ':' }
+        ]
+      },
+
+      // strong segments
+      {
+        className: 'strong',
+        variants: [
+          { begin: '^FATAL', end: ':' },
+          { begin: '^CRITICAL', end: ':' },
+          { begin: '^WARNING', end: ':' },
+          { begin: '^ERROR', end: ':' },
+          { begin: '^INFO', end: ':' },
+          { begin: '^LOG', end: ':' },
+          { begin: '^DEBUG', end: ':' },
+        ]
+      }
+    ]
+  };
+}

--- a/test/detect/pythonlogging/default.txt
+++ b/test/detect/pythonlogging/default.txt
@@ -1,0 +1,7 @@
+CRITICAL:logman:This is a FATAL message.
+CRITICAL:logman:This is a CRITICAL message.
+WARNING:logman:This is a WARNING message.
+INFO:logman:This is an INFO message.
+LOG:logman:This is a LOG message.
+ERROR:logman:This is an ERROR message.
+DEBUG:logman:This is a DEBUG message.


### PR DESCRIPTION
This pull request will add the base files for the python logging syntax highlighter for highlight.js. It includes:

 - the default.txt under test/detect/pythonlogging to provide an example to highlight
 - the pythonlogging.js file to define the terms for how to highlight, basically looking for the level strings at the beginning of the lines
 - a more descriptive readme and description.

@egor-rogov I think you're the only one I know to ask to review this!

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>